### PR TITLE
Adiciona 'search' na action do buyer

### DIFF
--- a/zoop_wrapper/wrapper/buyer.py
+++ b/zoop_wrapper/wrapper/buyer.py
@@ -94,7 +94,7 @@ class BuyerWrapper(BaseZoopWrapper):
         Returns:
             :class:`.ZoopResponse`
         """
-        url = self._construct_url(action="buyers", search=f"taxpayer_id={identifier}")
+        url = self._construct_url(action="buyers/search", search=f"taxpayer_id={identifier}")
         return self._get(url)
 
     def update_buyer(self, identifier: str, data: Union[dict, Buyer]) -> ZoopResponse:

--- a/zoop_wrapper/wrapper/buyer.py
+++ b/zoop_wrapper/wrapper/buyer.py
@@ -94,7 +94,9 @@ class BuyerWrapper(BaseZoopWrapper):
         Returns:
             :class:`.ZoopResponse`
         """
-        url = self._construct_url(action="buyers/search", search=f"taxpayer_id={identifier}")
+        url = self._construct_url(
+            action="buyers/search", search=f"taxpayer_id={identifier}"
+        )
         return self._get(url)
 
     def update_buyer(self, identifier: str, data: Union[dict, Buyer]) -> ZoopResponse:


### PR DESCRIPTION
A action do buyer estava errada, ao invez de retornar um buyer estava retornando uma listagem. Os testes não pegam esse caso pois é algo externo, apenas testes de integração detectariam isso.

Esse problema passou despercebido no PR https://github.com/imobanco/zoop-wrapper/pull/114

Isso foi a causa de https://github.com/imobanco/imopay-api/issues/126