### PR TITLE
Adiciona exemplo de update de business seller, atualmente quebrado WIP

### DIFF
--- a/examples/seller/update_business_seller.py
+++ b/examples/seller/update_business_seller.py
@@ -1,0 +1,36 @@
+import os
+from requests import HTTPError
+
+from zoop_wrapper import ZoopWrapper, Seller, Address
+from examples.utils import dump_response
+
+"""
+Nesse momento as constantes podem ser criadas no arquivo .py.
+Mas é recomendado utilizar como variável de ambiente em um '.env'
+"""
+from zoop_wrapper.constants import MARKETPLACE_ID, ZOOP_KEY
+
+
+client = ZoopWrapper(marketplace_id=MARKETPLACE_ID, key=ZOOP_KEY)
+
+s = Seller(
+    business_address=None,
+    business_email="foo",
+    business_name="foo",
+    business_opening_date="foo",
+    business_phone="foo",
+    business_website="foo",
+    ein="64070465954529",
+)
+
+seller_id = "d7b33dec57cf4a51862d5e795a51acc3"
+
+# TODO: remover esse try/except após exclarecimentos com zoop
+try:
+    response = client.update_seller(seller_id, s)
+except HTTPError as e:
+    print(e)
+
+dump_response(response, os.path.basename(__file__).split(".")[0])
+
+

--- a/examples/seller/update_business_seller.py
+++ b/examples/seller/update_business_seller.py
@@ -1,7 +1,7 @@
 import os
 from requests import HTTPError
 
-from zoop_wrapper import ZoopWrapper, Seller, Address
+from zoop_wrapper import ZoopWrapper, Seller
 from examples.utils import dump_response
 
 """
@@ -32,5 +32,3 @@ except HTTPError as e:
     print(e)
 
 dump_response(response, os.path.basename(__file__).split(".")[0])
-
-


### PR DESCRIPTION
Esse PR é dedicado resolver o problema de update de um business seller sem endereço, conforme descrito em #117.

No estado atual, WIP, foi adicionado um exemplo do caso descrito, que serve, por hora como forma de reproduzir o erro na Zoop.

Quando resolvido esse PR, ele resolverá:
- Closes #117
